### PR TITLE
Use env var for blacklist

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ var (
 func blacklistedMembers() map[string]bool {
 	ret := map[string]bool{}
 	buf := os.Getenv("BLACKLIST")
-	for _, login := range strings.Split(buf, ";") {
+	for _, login := range strings.Split(buf, ",") {
 		ret[login] = true
 	}
 	return ret


### PR DESCRIPTION
  Use the 'BLACKLIST' environment variable to define which members
  should not be defined in PR's.  Login's are seperated by ';'s.
